### PR TITLE
prefork in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,8 @@ COPY --from=build /go/src/management-backend/app .
 # Exposes port 3000 because our program listens on that port
 EXPOSE 3000
 
+# Set fake entrypoint to make sure fiber doesn't get PID 1
+RUN apk add dumb-init
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
 CMD ["./app", "--prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY --from=build /go/src/github.com/PranavBakre/management-backend/app .
 # Exposes port 3000 because our program listens on that port
 EXPOSE 3000
 
-CMD ["./app"]
+CMD ["./app", "--prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.15 AS build
 
 # `boilerplate` should be replaced with your project name
-WORKDIR /go/src/github.com/PranavBakre/management-backend
+WORKDIR /go/src/management-backend
 
 # Copy all the Code and stuff to compile everything
 COPY . .
@@ -20,7 +20,7 @@ FROM alpine:latest
 WORKDIR /app
 
 # `boilerplate` should be replaced here as well
-COPY --from=build /go/src/github.com/PranavBakre/management-backend/app .
+COPY --from=build /go/src/management-backend/app .
 
 # Exposes port 3000 because our program listens on that port
 EXPOSE 3000


### PR DESCRIPTION
- build: use prefork in prod
- build: no need to use full path when building project executable, since it actually has nothing to do with the go module name at all
- build: set fake entrypoint so that fiber app doesn't get PID 1
